### PR TITLE
Create repo-tracker.yml

### DIFF
--- a/.github/workflows/repo-tracker.yml
+++ b/.github/workflows/repo-tracker.yml
@@ -1,0 +1,42 @@
+name: Repository Tracker
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Runs daily at midnight
+  workflow_dispatch:     # Allows manual triggering
+
+jobs:
+  track-repos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Fetch repository data
+        id: search-repos
+        run: |
+          # Query GitHub API for matching repos (updated in last 30 days)
+          QUERY='Autonomi+in:description,readme+SAFE+Network+in:description,readme+pushed:>$(date -d "30 days ago" +%Y-%m-%d)'
+          REPOS_JSON=$(curl -s \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/search/repositories?q=$QUERY&sort=updated&order=desc")
+
+          # Process JSON into a Markdown table
+          echo "$REPOS_JSON" | jq -r '
+            ["Repo", "Description", "⭐ Stars", "Last Updated"],
+            ["----", "-----------", "---------", "-------------"],
+            (.items[] | [
+              "[" + .full_name + "](" + .html_url + ")",
+              .description // "N/A" | sub("\n"; " ") | .[0:100] + "...",
+              .stargazers_count,
+              .pushed_at | fromdate | strftime("%Y-%m-%d")
+            ])
+          | @tsv' | column -t -s $'\t' > AUTONOMI_SAFE_REPOS.md
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git add AUTONOMI_SAFE_REPOS.md
+          git commit -m "Update Autonomi/SAFE Network repo list"
+          git push

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@
 
 | Repository | Description | Updated | Stars |
 |------------|-------------|---------|-------|
+| [Champii/Mutant](https://github.com/Champii/Mutant) | Decentralized P2P Storage with Mutable Key/Value over the Autonomi Network | 2025-04-20 | 7 |
 | [bochaco/formicaio](https://github.com/bochaco/formicaio) | Formicaio is an intuitive application designed to help you run nodes on the Autonomi network. This P2P network allows users to share storage and bandwidth in exchange for ANT tokens, an ERC-20 token on the Arbitrum One network. | 2025-04-19 | 3 |
-| [Champii/Mutant](https://github.com/Champii/Mutant) | Decentralized P2P Storage with Mutable Key/Value over the Autonomi Network | 2025-04-19 | 5 |
 | [Madcowe/ant-counter](https://github.com/Madcowe/ant-counter) | A simple counter app that stores it's data on the autonomi network | 2025-04-19 | 0 |
 | [maidsafe/ant-network-workflow-runner](https://github.com/maidsafe/ant-network-workflow-runner) | A CLI for running Github Actions workflows that launch and manage Autonomi networks | 2025-04-18 | 0 |
 | [safenetforum-community/community-token](https://github.com/safenetforum-community/community-token) | Autonomi token standard, that enables issuing own token by anyone – from scratch, or by wrapping existing ERC20 tokens. | 2025-04-18 | 0 |
@@ -33,8 +33,8 @@
 | [SafeMedia/autonomi](https://github.com/SafeMedia/autonomi) | Autonomi Client JS | 2024-10-26 | 0 |
 | [intercloud/terraform-provider-autonomi](https://github.com/intercloud/terraform-provider-autonomi) | Terraform provider for Autonomi platform | 2024-10-08 | 1 |
 | [wiikviz/NTracking](https://github.com/wiikviz/NTracking) | NTacking Dashboard for Autonomi Network | 2024-07-16 | 0 |
+| [Champii/Mutant](https://github.com/Champii/Mutant) | Decentralized P2P Storage with Mutable Key/Value over the Autonomi Network | 2025-04-20 | 7 |
 | [bochaco/formicaio](https://github.com/bochaco/formicaio) | Formicaio is an intuitive application designed to help you run nodes on the Autonomi network. This P2P network allows users to share storage and bandwidth in exchange for ANT tokens, an ERC-20 token on the Arbitrum One network. | 2025-04-19 | 3 |
-| [Champii/Mutant](https://github.com/Champii/Mutant) | Decentralized P2P Storage with Mutable Key/Value over the Autonomi Network | 2025-04-19 | 5 |
 | [Madcowe/ant-counter](https://github.com/Madcowe/ant-counter) | A simple counter app that stores it's data on the autonomi network | 2025-04-19 | 0 |
 | [maidsafe/ant-network-workflow-runner](https://github.com/maidsafe/ant-network-workflow-runner) | A CLI for running Github Actions workflows that launch and manage Autonomi networks | 2025-04-18 | 0 |
 | [safenetforum-community/community-token](https://github.com/safenetforum-community/community-token) | Autonomi token standard, that enables issuing own token by anyone – from scratch, or by wrapping existing ERC20 tokens. | 2025-04-18 | 0 |
@@ -63,8 +63,8 @@
 | [SafeMedia/autonomi](https://github.com/SafeMedia/autonomi) | Autonomi Client JS | 2024-10-26 | 0 |
 | [intercloud/terraform-provider-autonomi](https://github.com/intercloud/terraform-provider-autonomi) | Terraform provider for Autonomi platform | 2024-10-08 | 1 |
 | [wiikviz/NTracking](https://github.com/wiikviz/NTracking) | NTacking Dashboard for Autonomi Network | 2024-07-16 | 0 |
+| [Champii/Mutant](https://github.com/Champii/Mutant) | Decentralized P2P Storage with Mutable Key/Value over the Autonomi Network | 2025-04-20 | 7 |
 | [bochaco/formicaio](https://github.com/bochaco/formicaio) | Formicaio is an intuitive application designed to help you run nodes on the Autonomi network. This P2P network allows users to share storage and bandwidth in exchange for ANT tokens, an ERC-20 token on the Arbitrum One network. | 2025-04-19 | 3 |
-| [Champii/Mutant](https://github.com/Champii/Mutant) | Decentralized P2P Storage with Mutable Key/Value over the Autonomi Network | 2025-04-19 | 5 |
 | [Madcowe/ant-counter](https://github.com/Madcowe/ant-counter) | A simple counter app that stores it's data on the autonomi network | 2025-04-19 | 0 |
 | [maidsafe/ant-network-workflow-runner](https://github.com/maidsafe/ant-network-workflow-runner) | A CLI for running Github Actions workflows that launch and manage Autonomi networks | 2025-04-18 | 0 |
 | [saykorz/AutonomiNet](https://github.com/saykorz/AutonomiNet) | .net library for Autonomi Network | 2025-04-14 | 0 |
@@ -76,8 +76,8 @@
 | [NAFORadio/TheLifeMachine](https://github.com/NAFORadio/TheLifeMachine) | The first full length community member music album available only on the Autonomi Network.  | 2025-02-21 | 0 |
 | [safenetforum-community/ant-agent](https://github.com/safenetforum-community/ant-agent) | Distributed load and test Agent for the Autonomi Network | 2025-01-25 | 1 |
 | [wiikviz/NTracking](https://github.com/wiikviz/NTracking) | NTacking Dashboard for Autonomi Network | 2024-07-16 | 0 |
+| [Champii/Mutant](https://github.com/Champii/Mutant) | Decentralized P2P Storage with Mutable Key/Value over the Autonomi Network | 2025-04-20 | 7 |
 | [bochaco/formicaio](https://github.com/bochaco/formicaio) | Formicaio is an intuitive application designed to help you run nodes on the Autonomi network. This P2P network allows users to share storage and bandwidth in exchange for ANT tokens, an ERC-20 token on the Arbitrum One network. | 2025-04-19 | 3 |
-| [Champii/Mutant](https://github.com/Champii/Mutant) | Decentralized P2P Storage with Mutable Key/Value over the Autonomi Network | 2025-04-19 | 5 |
 | [Madcowe/ant-counter](https://github.com/Madcowe/ant-counter) | A simple counter app that stores it's data on the autonomi network | 2025-04-19 | 0 |
 | [maidsafe/ant-network-workflow-runner](https://github.com/maidsafe/ant-network-workflow-runner) | A CLI for running Github Actions workflows that launch and manage Autonomi networks | 2025-04-18 | 0 |
 | [saykorz/AutonomiNet](https://github.com/saykorz/AutonomiNet) | .net library for Autonomi Network | 2025-04-14 | 0 |
@@ -89,7 +89,7 @@
 | [NAFORadio/TheLifeMachine](https://github.com/NAFORadio/TheLifeMachine) | The first full length community member music album available only on the Autonomi Network.  | 2025-02-21 | 0 |
 | [safenetforum-community/ant-agent](https://github.com/safenetforum-community/ant-agent) | Distributed load and test Agent for the Autonomi Network | 2025-01-25 | 1 |
 | [wiikviz/NTracking](https://github.com/wiikviz/NTracking) | NTacking Dashboard for Autonomi Network | 2024-07-16 | 0 |
-| [safenetforum-community/AutonomiCommunityProjectTracker](https://github.com/safenetforum-community/AutonomiCommunityProjectTracker) |  script to crawl GitHub for projects referencing Autonomomi or SAFE Network | 2025-04-19 | 1 |
+| [safenetforum-community/AutonomiCommunityProjectTracker](https://github.com/safenetforum-community/AutonomiCommunityProjectTracker) |  script to crawl GitHub for projects referencing Autonomomi or SAFE Network | 2025-04-20 | 1 |
 | [PanktiSP13/BookHub-jetpack-compose-modular-project](https://github.com/PanktiSP13/BookHub-jetpack-compose-modular-project) | Project showcases the use of MVI architecture, Clean Architecture, safe network calls with Retrofit, Hilt for DI. It leverages Kotlin 2.0, latest Android SDK 35, Jetpack Compose with declarative approach, app modularization  & reactive programming with Kotlin Flow. | 2025-01-28 | 0 |
 | [osmancan23/ChatFlow](https://github.com/osmancan23/ChatFlow) | 🚀 Modern messaging app showcasing Flutter clean architecture, type-safe network layer & real-time features with Firebase | 2025-01-26 | 0 |
 | [TosiaCh/AlgorithmsAndDataStructures](https://github.com/TosiaCh/AlgorithmsAndDataStructures) | This repository contains three projects: a transport path finder to calculate the shortest routes in a transport network, a library manager for books, movies, and music, and a graph-based safe network solver to break cycles in a network of safes. | 2025-01-13 | 0 |
@@ -98,7 +98,7 @@
 | [happybeing/safe-filesystem](https://github.com/happybeing/safe-filesystem) | A POSIX compatible 'local-first' filesystem API for Safe Network | 2024-02-19 | 0 |
 | [happybeing/shareable-p2p-drive](https://github.com/happybeing/shareable-p2p-drive) | A secure, shareable, decentralised drive for Safe Network with local-first, multi-user read/write access | 2024-02-19 | 0 |
 | [willief/ntracking](https://github.com/willief/ntracking) | Set Up Safe Network Nodes Stats & Tracking. | 2024-02-10 | 0 |
-| [safenetforum-community/AutonomiCommunityProjectTracker](https://github.com/safenetforum-community/AutonomiCommunityProjectTracker) |  script to crawl GitHub for projects referencing Autonomomi or SAFE Network | 2025-04-19 | 1 |
+| [safenetforum-community/AutonomiCommunityProjectTracker](https://github.com/safenetforum-community/AutonomiCommunityProjectTracker) |  script to crawl GitHub for projects referencing Autonomomi or SAFE Network | 2025-04-20 | 1 |
 | [PanktiSP13/BookHub-jetpack-compose-modular-project](https://github.com/PanktiSP13/BookHub-jetpack-compose-modular-project) | Project showcases the use of MVI architecture, Clean Architecture, safe network calls with Retrofit, Hilt for DI. It leverages Kotlin 2.0, latest Android SDK 35, Jetpack Compose with declarative approach, app modularization  & reactive programming with Kotlin Flow. | 2025-01-28 | 0 |
 | [osmancan23/ChatFlow](https://github.com/osmancan23/ChatFlow) | 🚀 Modern messaging app showcasing Flutter clean architecture, type-safe network layer & real-time features with Firebase | 2025-01-26 | 0 |
 | [TosiaCh/AlgorithmsAndDataStructures](https://github.com/TosiaCh/AlgorithmsAndDataStructures) | This repository contains three projects: a transport path finder to calculate the shortest routes in a transport network, a library manager for books, movies, and music, and a graph-based safe network solver to break cycles in a network of safes. | 2025-01-13 | 0 |
@@ -108,4 +108,4 @@
 | [happybeing/shareable-p2p-drive](https://github.com/happybeing/shareable-p2p-drive) | A secure, shareable, decentralised drive for Safe Network with local-first, multi-user read/write access | 2024-02-19 | 0 |
 | [willief/ntracking](https://github.com/willief/ntracking) | Set Up Safe Network Nodes Stats & Tracking. | 2024-02-10 | 0 |
 | [safenetforum-community/safenet-faq](https://github.com/safenetforum-community/safenet-faq) |  Gathering information from Maidsafe forum  | 2024-02-14 | 0 |
-| [safenetforum-community/AutonomiCommunityProjectTracker](https://github.com/safenetforum-community/AutonomiCommunityProjectTracker) |  script to crawl GitHub for projects referencing Autonomomi or SAFE Network | 2025-04-19 | 1 |
+| [safenetforum-community/AutonomiCommunityProjectTracker](https://github.com/safenetforum-community/AutonomiCommunityProjectTracker) |  script to crawl GitHub for projects referencing Autonomomi or SAFE Network | 2025-04-20 | 1 |


### PR DESCRIPTION
Requires jq (pre-installed in GitHub Actions).

Uses secrets.GITHUB_TOKEN (no extra auth needed).

For private repos, you’d need a personal access token with repo scope.

